### PR TITLE
Changed ping messages to embeds for readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Poetry
+poetry.lock
+pyproject.toml

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from discord.ext import tasks
 PING_LOG_LOCATION = "pinglog.log"
 SECRET_LOCATION = "secret.txt"
 RSS_URL = "https://ctftime.org/event/list/upcoming/rss/"
-CHANNEL_ID = 1107657511793864788 # band-stuff
+CHANNEL_ID = 1309395368475230238 # band-stuff
 PING_CYCLE_TIME = 30 # seconds
 
 feed = feedparser.parse(RSS_URL) 

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from discord.ext import tasks
 PING_LOG_LOCATION = "pinglog.log"
 SECRET_LOCATION = "secret.txt"
 RSS_URL = "https://ctftime.org/event/list/upcoming/rss/"
-CHANNEL_ID = 1309395368475230238 # band-stuff
+CHANNEL_ID = 1107657511793864788 # band-stuff
 PING_CYCLE_TIME = 30 # seconds
 
 feed = feedparser.parse(RSS_URL) 
@@ -49,15 +49,19 @@ async def ping_for_new_ctf(ctf, channel):
     'weight', 'live_feed', 'restrictions', 'location', 'onsite', 'organizers', 'ctf_id', 'ctf_name'] '''
 
     print("Ping!")
-    await channel.send(
-        "\n========== <@&1311949816644767775> ===========" +
-        "\n## CTF: " + ctf.title +
-        "\n**Links:**  [CTF Time](" + ctf.link + ")" + ",  [Offical CTF Wepage](<" + ctf.href + ">)" +
-        "\n**CTF Weight:**  " + ctf.weight +
-        "\n**Date/Time (Adl):**  " + date_time_string_to_local_datetime_string(ctf.start_date) + "  (" + generate_countdown(ctf.start_date) + ")" +
-        "\n                             to:  " + date_time_string_to_local_datetime_string(ctf.finish_date) +
-        "\n\n========== <@&1311949816644767775> ==========="
-        )
+    await channel.send("<@&1311949816644767775> New CTF!")
+
+    embed=discord.Embed(title=f"{ctf.title}", color=0x8000ff)
+
+    embed_img = f"https://ctftime.org{ctf.logo_url}"
+    # print(embed_img)
+    embed.set_thumbnail(url=embed_img)
+
+    embed.add_field(name="Links:", value=f"[CTF Time]({ctf.link}) | [Official CTF Webpage]({ctf.href})", inline=True)
+    embed.add_field(name="CTF Weight:", value=f"{ctf.weight}", inline=True)
+    embed.add_field(name="Date/Time (Adl):", value=f"**from: **{date_time_string_to_local_datetime_string(ctf.start_date)} ({generate_countdown(ctf.start_date)})\n**to:** {date_time_string_to_local_datetime_string(ctf.finish_date)}", inline=False)
+
+    await channel.send(embed=embed)
 
 @tasks.loop(seconds=PING_CYCLE_TIME)
 async def discord_ping_cycle(channel):


### PR DESCRIPTION
Changed the notification messages being sent for each new CTF to Discord embedded messages. This increases readability and allows for an in-line thumbnail which is very visually appealing.
Example:
![image](https://github.com/user-attachments/assets/8ad4ef89-55b7-4119-b480-ccb1a85736f3)